### PR TITLE
解决fork的时候,报空指针的问题(原因是dragonos目前不支持thread local)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ version = "0.1.0"
 [[package]]
 name = "dragonos-dsc"
 version = "0.0.1"
+source = "git+https://github.com/DragonOS-Community/dsc.git?rev=f57e668#f57e6686c1c6d10210e2dbb7b073c50f305bebc5"
 
 [[package]]
 name = "errno"

--- a/src/header/unistd/mod.rs
+++ b/src/header/unistd/mod.rs
@@ -37,7 +37,12 @@ pub const STDIN_FILENO: c_int = 0;
 pub const STDOUT_FILENO: c_int = 1;
 pub const STDERR_FILENO: c_int = 2;
 
+#[cfg(not(target_os = "dragonos"))]
 #[thread_local]
+pub static mut fork_hooks_static: Option<[LinkedList<extern "C" fn()>; 3]> = None;
+
+/// due to dragonos not supporting thread_local, we need to use a static directly
+#[cfg(target_os = "dragonos")]
 pub static mut fork_hooks_static: Option<[LinkedList<extern "C" fn()>; 3]> = None;
 
 unsafe fn init_fork_hooks<'a>() -> &'a mut [LinkedList<extern "C" fn()>; 3] {


### PR DESCRIPTION
问题产生的原因是dragonos目前暂时不支持thread local storage，因此导致relibc的[fork_hooks_static](https://opengrok.ringotek.cn/s?refs=fork_hooks_static&project=dragonos-relibc)变量指向空值。

由于目前dragonos每个进程只支持1线程，因此只需要删掉thread_local标签即可
对应issue: 
https://github.com/DragonOS-Community/DragonOS/issues/313

