### PR TITLE
Patch add sys ftruncate

### DIFF
--- a/src/platform/allocator/dragonos_malloc.rs
+++ b/src/platform/allocator/dragonos_malloc.rs
@@ -68,7 +68,7 @@ pub unsafe fn realloc(ptr: *mut c_void, size: size_t) -> *mut c_void {
         return null_mut();
     }
 
-    let old_len = _dragonos_chunk_length(ptr);
+    let old_len = _dragonos_chunk_length(ptr) - 16;
 
     // 暴力实现
 

--- a/src/platform/dragonos/mod.rs
+++ b/src/platform/dragonos/mod.rs
@@ -223,8 +223,7 @@ impl Pal for Sys {
     }
 
     fn ftruncate(fildes: c_int, length: off_t) -> c_int {
-        // e(unsafe { syscall!(FTRUNCATE, fildes, length) }) as c_int
-        unimplemented!()
+        e(unsafe { syscall!(SYS_FTRUNCATE, fildes, length) }) as c_int
     }
 
     fn futex(addr: *mut c_int, op: c_int, val: c_int, val2: usize) -> c_int {
@@ -279,8 +278,7 @@ impl Pal for Sys {
     }
 
     fn getpagesize() -> usize {
-        // 4096
-        1024 * 1024 * 2
+        return 4096;
     }
 
     fn getpgid(pid: pid_t) -> pid_t {


### PR DESCRIPTION
1. bugfix: realloc时，旧块长度计算错误导致的内存越界问题
2. 增加ftruncate